### PR TITLE
Bot will send every member of a channel a DM when pinged

### DIFF
--- a/lib/tracker_bot.js
+++ b/lib/tracker_bot.js
@@ -7,11 +7,20 @@ function TrackerBot(slack, client, projectId) {
 };
 
 method.handleMessage = function(message) {
-  channel = this.slack.getChannelGroupOrDMByID(message.channel);
+  var channel = this.slack.getChannelGroupOrDMByID(message.channel);
+  var that = this;
+  var members = channel.members;
+
   this.client.project(this.projectId).stories.all(function(error, stories) {
     if (error) {
         console.log(error);
     } else {
+      for (var i = 0; i < members.length; i ++) {
+        that.slack.openDM(members[i], function(dM){
+          var dMChannel = that.slack.getChannelGroupOrDMByID(dM.channel.id);
+          dMChannel.send("I'm in DM now!");
+        });
+      }
       channel.send("Next story: " + stories[0].name + " (" + stories[0].url + ")");
     }
   });


### PR DESCRIPTION
We'll probably need to provide the bot with users it should DM, since Slack channels don't distinguish between channel "owners" and "visitors".